### PR TITLE
docs(readme): update minimum required Node version to 18

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ A versatile TV app developed in React Native, compatible with Android TV, Fire T
 ## 📋 Prerequisites
 
 Before you begin, ensure you have the following installed:
-- [Node.js](https://nodejs.org/) (v14 or later)
+- [Node.js](https://nodejs.org/) (v18 or later)
 - [npm](https://www.npmjs.com/)
 - [JDK 17](https://developer.android.com/build/jdks)
 


### PR DESCRIPTION
*Issue #, if available:*

_No issue available_

*Description of changes:*

Expo guarantees everything works on, at minimum, "active" (20) or "maintenance" (18) LTS [Node versions](https://nodejs.org/en/about/previous-releases). You can see this through our CI ([Expo CLI](https://github.com/expo/expo/blob/9ae838bc226a9c14f4d70fd1d73ddce2c9cc739d/.github/workflows/cli.yml#L58) / [EAS CLI](https://github.com/expo/eas-cli/blob/fc88d65691246fdcf58a88b1506cfb50d5433410/.github/workflows/test.yml#L18)) - EOL Node versions are technically not supported anymore.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

^ Yes :)
