### PR TITLE
fix(android): resolve JVM target mismatch for JDK 22 users

### DIFF
--- a/apps/expo-multi-tv/app.json
+++ b/apps/expo-multi-tv/app.json
@@ -1,6 +1,7 @@
 {
   "expo": {
     "plugins": [
+      "./plugins/withKotlinJvmTarget",
       "@bam.tech/react-native-keyevent-expo-config-plugin",
       [
         "@react-native-tvos/config-tv",
@@ -24,7 +25,11 @@
             "newArchEnabled": false
           },
           "android": {
-            "newArchEnabled": false
+            "newArchEnabled": false,
+            "kotlinVersion": "1.9.24",
+            "compileSdkVersion": 34,
+            "targetSdkVersion": 34,
+            "minSdkVersion": 23
           }
         }
       ],

--- a/apps/expo-multi-tv/plugins/withKotlinJvmTarget.js
+++ b/apps/expo-multi-tv/plugins/withKotlinJvmTarget.js
@@ -1,0 +1,44 @@
+const { withDangerousMod } = require("expo/config-plugins");
+const fs = require("fs");
+const path = require("path");
+
+function withKotlinJvmTarget(config) {
+  return withDangerousMod(config, [
+    "android",
+    async (config) => {
+      const buildGradlePath = path.join(
+        config.modRequest.platformProjectRoot,
+        "react-settings-plugin",
+        "build.gradle.kts"
+      );
+
+      if (fs.existsSync(buildGradlePath)) {
+        let contents = fs.readFileSync(buildGradlePath, "utf-8");
+
+        if (!contents.includes("sourceCompatibility")) {
+          const jvmConfig = `
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}
+
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+}
+`;
+          contents = contents.replace(
+            /repositories\s*\{\s*mavenCentral\(\)\s*\}/,
+            (match) => match + "\n" + jvmConfig
+          );
+          fs.writeFileSync(buildGradlePath, contents);
+        }
+      }
+
+      return config;
+    },
+  ]);
+}
+
+module.exports = withKotlinJvmTarget;


### PR DESCRIPTION
Add Expo config plugin to set consistent Java 17 / Kotlin JVM targets in the react-settings-plugin, preventing the "Inconsistent JVM-target compatibility" error when building with JDK 22. Also pin kotlinVersion and SDK versions in expo-build-properties for reproducibility.

Closes #56
