### PR TITLE
[docs](README): Added iOS Troubleshooting for fmt error

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,6 +438,11 @@ Contributions are welcome! This project is an open-source sample designed to hel
 
 ### iOS Build Issues
 
+**Error: "❌  (ios/Pods/fmt/include/xxx)"**
+
+- This error is related to [this blog post](https://bleepingswift.com/blog/fmt-consteval-error-xcode-26-4-react-native)
+- Solution: Downgrade Xcode to [version 26.3](https://xcodereleases.com) or below
+
 **Error: "can't access lexical declaration 'X' before initialization"**
 
 - This typically occurs when functions are referenced before they're defined


### PR DESCRIPTION
# Description

Added troubleshooting information for iOS build issues on Xcode 26.4+


## Type of change

-  📝 Documentation Update

## Added tests?

-  🙅 No, because they aren't needed

## Internationalization Support?

-  🙅 No, because they aren't needed


"By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice."